### PR TITLE
Update coinor.cmake

### DIFF
--- a/libraries.cmake/coinor.cmake
+++ b/libraries.cmake/coinor.cmake
@@ -23,6 +23,10 @@ MACRO( OPENMS_CONTRIB_BUILD_COINOR)
     set(PATCH_FILE "${PATCH_DIR}/coinor/CoinLpIO.diff")
     set(PATCHED_FILE "${COINOR_DIR}/CoinUtils/src/CoinLpIO.cpp")
     OPENMS_PATCH( PATCH_FILE COINOR_DIR PATCHED_FILE)
+    
+    set(PATCH_FILE "${PATCH_DIR}/coinor/CoinTypes.hpp.diff")
+    set(PATCHED_FILE "${COINOR_DIR}/CoinUtils/src/CoinTypes.hpp")
+    OPENMS_PATCH( PATCH_FILE COINOR_DIR PATCHED_FILE)
 	
     set(MSBUILD_ARGS_SLN "${COINOR_DIR}/CoinMP/MSVisualStudio/v${CONTRIB_MSVC_VERSION}/CoinMP.sln")
     set(MSBUILD_ARGS_TARGET "libCbc")

--- a/libraries.cmake/coinor.cmake
+++ b/libraries.cmake/coinor.cmake
@@ -86,7 +86,7 @@ MACRO( OPENMS_CONTRIB_BUILD_COINOR)
   
     # configure -- 
     if( ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" )
-      set(COINOR_EXTRA_FLAGS "CFLAGS='${CXX_OSX_FLAGS}' CXXFLAGS='${CXX_OSX_FLAGS} -stdlib=libstdc++ -fPIC' LDFLAGS='-stdlib=libstdc++' LIBS='-lstdc++' --disable-dependency-tracking")
+      set(COINOR_EXTRA_FLAGS "CFLAGS='${CXX_OSX_FLAGS}' CXXFLAGS='${CXX_OSX_FLAGS} -fPIC' --disable-dependency-tracking")
     else()
       set(COINOR_EXTRA_FLAGS "CXXFLAGS='-fPIC'")
     endif()    

--- a/libraries.cmake/coinor.cmake
+++ b/libraries.cmake/coinor.cmake
@@ -82,7 +82,7 @@ MACRO( OPENMS_CONTRIB_BUILD_COINOR)
   
     # configure -- 
     if( ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" )
-      set(COINOR_EXTRA_FLAGS "CFLAGS='${CXX_OSX_FLAGS}' CXXFLAGS='${CXX_OSX_FLAGS} -stdlib=libstdc++ -fPIC' --disable-dependency-tracking")
+      set(COINOR_EXTRA_FLAGS "CFLAGS='${CXX_OSX_FLAGS}' CXXFLAGS='${CXX_OSX_FLAGS} -stdlib=libstdc++ -fPIC' LDFLAGS='-stdlib=libstdc++' LIBS='-lstdc++' --disable-dependency-tracking")
     else()
       set(COINOR_EXTRA_FLAGS "CXXFLAGS='-fPIC'")
     endif()    

--- a/libraries.cmake/coinor.cmake
+++ b/libraries.cmake/coinor.cmake
@@ -82,7 +82,7 @@ MACRO( OPENMS_CONTRIB_BUILD_COINOR)
   
     # configure -- 
     if( ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" )
-      set(COINOR_EXTRA_FLAGS "CFLAGS='${CXX_OSX_FLAGS}' CXXFLAGS='${CXX_OSX_FLAGS} -fPIC' --disable-dependency-tracking")
+      set(COINOR_EXTRA_FLAGS "CFLAGS='${CXX_OSX_FLAGS}' CXXFLAGS='${CXX_OSX_FLAGS} -stdlib=libstdc++ -fPIC' --disable-dependency-tracking")
     else()
       set(COINOR_EXTRA_FLAGS "CXXFLAGS='-fPIC'")
     endif()    

--- a/libraries.cmake/coinor.cmake
+++ b/libraries.cmake/coinor.cmake
@@ -23,10 +23,6 @@ MACRO( OPENMS_CONTRIB_BUILD_COINOR)
     set(PATCH_FILE "${PATCH_DIR}/coinor/CoinLpIO.diff")
     set(PATCHED_FILE "${COINOR_DIR}/CoinUtils/src/CoinLpIO.cpp")
     OPENMS_PATCH( PATCH_FILE COINOR_DIR PATCHED_FILE)
-    
-    set(PATCH_FILE "${PATCH_DIR}/coinor/CoinTypes.hpp.diff")
-    set(PATCHED_FILE "${COINOR_DIR}/CoinUtils/src/CoinTypes.hpp")
-    OPENMS_PATCH( PATCH_FILE COINOR_DIR PATCHED_FILE)
 	
     set(MSBUILD_ARGS_SLN "${COINOR_DIR}/CoinMP/MSVisualStudio/v${CONTRIB_MSVC_VERSION}/CoinMP.sln")
     set(MSBUILD_ARGS_TARGET "libCbc")
@@ -81,8 +77,12 @@ MACRO( OPENMS_CONTRIB_BUILD_COINOR)
 
 	else()  ## LINUX & Mac
     set(PATCH_FILE "${PROJECT_SOURCE_DIR}/patches/coinor/CbcEventHandler.hpp.diff")
-	  set(PATCHED_FILE "${COINOR_DIR}/Cbc/src/CbcEventHandler.hpp")
-	  OPENMS_PATCH( PATCH_FILE COINOR_DIR PATCHED_FILE)
+    set(PATCHED_FILE "${COINOR_DIR}/Cbc/src/CbcEventHandler.hpp")
+    OPENMS_PATCH( PATCH_FILE COINOR_DIR PATCHED_FILE)
+
+    set(PATCH_FILE "${PROJECT_SOURCE_DIR}/patches/coinor/CoinTypes.hpp.diff")
+    set(PATCHED_FILE "${COINOR_DIR}/CoinUtils/src/CoinTypes.hpp")
+    OPENMS_PATCH( PATCH_FILE COINOR_DIR PATCHED_FILE)	  
   
     # configure -- 
     if( ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" )

--- a/patches/coinor/CoinTypes.hpp.diff
+++ b/patches/coinor/CoinTypes.hpp.diff
@@ -1,5 +1,5 @@
---- /CoinUtils/src/CoinTypes.hpp Fri Dec 11 11:38:03 2015
-+++ /CoinUtils/src/CoinTypes.hpp Fri Dec 11 11:38:09 2015
+--- /CoinUtils/src/CoinTypes.hpp
++++ /CoinUtils/src/CoinTypes.hpp
 @@ -7,7 +7,11 @@
  #include "CoinUtilsConfig.h"
 

--- a/patches/coinor/CoinTypes.hpp.diff
+++ b/patches/coinor/CoinTypes.hpp.diff
@@ -1,0 +1,15 @@
+--- /CoinUtils/src/CoinTypes.hpp Fri Dec 11 11:38:03 2015
++++ /CoinUtils/src/CoinTypes.hpp Fri Dec 11 11:38:09 2015
+@@ -7,7 +7,11 @@
+ #include "CoinUtilsConfig.h"
+
+ #ifdef HAVE_CINTTYPES
+-# include <cinttypes>
++# ifdef _LIBCPP_VERSION
++#  include <cinttypes>
++# else
++#  include <tr1/cinttypes>
++# endif
+ #else
+ # ifdef HAVE_INTTYPES_H
+ #  include <inttypes.h>

--- a/patches/coinor/CoinTypes.hpp.diff
+++ b/patches/coinor/CoinTypes.hpp.diff
@@ -1,5 +1,5 @@
---- /CoinUtils/src/CoinTypes.hpp
-+++ /CoinUtils/src/CoinTypes.hpp
+--- CoinUtils/src/CoinTypes.hpp
++++ CoinUtils/src/CoinTypes.hpp
 @@ -7,7 +7,11 @@
  #include "CoinUtilsConfig.h"
 


### PR DESCRIPTION
Solves a problem with MacOSX > 10.9 (maybe even earlier) where the CoinOR configuration fails due to a switch in default stdlibrary implementation. In the new (llvm libc++) library the namespace for cinttypes does not have to be prefixed by the (temporarily introduced) tr1 prefix. If the old (stdlibc++) is used this prefix is however needed.
